### PR TITLE
Use IndexMap for ImportList to guarantee consistent order (issue #10)

### DIFF
--- a/ts_export/Cargo.toml
+++ b/ts_export/Cargo.toml
@@ -17,6 +17,7 @@ log = "0.4"
 serde_json = "1.0"
 cargo_toml = "0.8"
 result = "1.0"
+indexmap = "1.6.1"
 
 [dev-dependencies]
 pretty_env_logger = "0.4"

--- a/ts_export/src/import.rs
+++ b/ts_export/src/import.rs
@@ -1,5 +1,5 @@
+use indexmap::IndexMap;
 use proc_macro2::Span;
-use std::collections::HashMap;
 use syn::{
     punctuated::Punctuated, token::Colon2, Ident, Item, Path, PathArguments, PathSegment, TypePath,
     UseTree,
@@ -48,10 +48,10 @@ impl Default for ImportContext {
 
 #[derive(Debug, Default)]
 /// An ImportList matches the last segment to the rest of
-pub struct ImportList(HashMap<Ident, Vec<PathSegment>>);
+pub struct ImportList(IndexMap<Ident, Vec<PathSegment>>);
 
 impl std::ops::Deref for ImportList {
-    type Target = HashMap<Ident, Vec<PathSegment>>;
+    type Target = IndexMap<Ident, Vec<PathSegment>>;
 
     fn deref(&self) -> &Self::Target {
         &self.0


### PR DESCRIPTION
This is supposed to solve https://github.com/impero-com/ts_export/issues/10